### PR TITLE
build: refactor CMakeLists files to use emil_build_for

### DIFF
--- a/examples/clicking_scrolling/CMakeLists.txt
+++ b/examples/clicking_scrolling/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_executable(examples.clicking_scrolling)
-
 emil_build_for(examples.clicking_scrolling HOST Windows TARGET_MCU stm32f746 PREREQUISITE_BOOL PREVIEW_BUILD_EXAMPLES)
+
 set_target_properties(examples.clicking_scrolling PROPERTIES WIN32_EXECUTABLE $<BOOL:${EMIL_BUILD_WIN}>)
 target_compile_definitions(examples.clicking_scrolling PUBLIC NOMINMAX)
 

--- a/preview/interfaces/CMakeLists.txt
+++ b/preview/interfaces/CMakeLists.txt
@@ -53,9 +53,5 @@ target_sources(preview.interfaces PRIVATE
     WindowBitmapCanvas.hpp
 )
 
-if (BUILD_TESTING)
-    add_subdirectory(test_doubles)
-endif()
-if (PREVIEW_BUILD_TESTS)
-    add_subdirectory(test)
-endif()
+add_subdirectory(test_doubles)
+add_subdirectory(test)

--- a/preview/interfaces/test/CMakeLists.txt
+++ b/preview/interfaces/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(preview.interfaces.test)
+emil_build_for(preview.interfaces.test BOOL PREVIEW_BUILD_TESTS)
 add_test(NAME preview.interfaces.test COMMAND preview.interfaces.test)
 
 target_link_libraries(preview.interfaces.test PUBLIC

--- a/preview/interfaces/test_doubles/CMakeLists.txt
+++ b/preview/interfaces/test_doubles/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(preview.interfaces.test_doubles ${PREVIEW_EXCLUDE_FROM_ALL} INTERFACE)
+emil_build_for(preview.interfaces.test_doubles BOOL BUILD_TESTING)
 
 target_link_libraries(preview.interfaces.test_doubles INTERFACE
     gmock

--- a/preview/stm32fxxx/CMakeLists.txt
+++ b/preview/stm32fxxx/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_library(preview.stm32fxxx STATIC)
-install(TARGETS preview.stm32fxxx EXPORT previewTargets)
-
 emil_build_for(preview.stm32fxxx TARGET_MCU_FAMILY stm32f7xx PREREQUISITE_BOOL PREVIEW_STANDALONE)
+install(TARGETS preview.stm32fxxx EXPORT previewTargets)
 
 target_include_directories(preview.stm32fxxx PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/../..>"

--- a/preview/touch/CMakeLists.txt
+++ b/preview/touch/CMakeLists.txt
@@ -41,6 +41,4 @@ target_sources(preview.touch PRIVATE
     TouchViewSelector.cpp
 )
 
-if (PREVIEW_BUILD_TESTS)
-    add_subdirectory(test)
-endif()
+add_subdirectory(test)

--- a/preview/touch/test/CMakeLists.txt
+++ b/preview/touch/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(preview.touch.test)
+emil_build_for(preview.touch.test BOOL PREVIEW_BUILD_TESTS)
 add_test(NAME preview.touch.test COMMAND preview.touch.test)
 
 target_link_libraries(preview.touch.test PUBLIC

--- a/preview/views/CMakeLists.txt
+++ b/preview/views/CMakeLists.txt
@@ -61,6 +61,4 @@ target_sources(preview.views PRIVATE
     ViewTitledFrame.hpp
 )
 
-if (PREVIEW_BUILD_TESTS)
-    add_subdirectory(test)
-endif()
+add_subdirectory(test)

--- a/preview/views/test/CMakeLists.txt
+++ b/preview/views/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(preview.views.test)
+emil_build_for(preview.views.test BOOL PREVIEW_BUILD_TESTS)
 add_test(NAME preview.views.test COMMAND preview.views.test)
 
 target_link_libraries(preview.views.test PUBLIC


### PR DESCRIPTION
build: refactor CMakeLists files to use emil_build_for instead of conditionally adding targets