### PR TITLE
chore: use emil_add_test instead of add_test

### DIFF
--- a/preview/interfaces/test/CMakeLists.txt
+++ b/preview/interfaces/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_executable(preview.interfaces.test)
 emil_build_for(preview.interfaces.test BOOL PREVIEW_BUILD_TESTS)
-add_test(NAME preview.interfaces.test COMMAND preview.interfaces.test)
+emil_add_test(preview.interfaces.test)
 
 target_link_libraries(preview.interfaces.test PUBLIC
     preview.interfaces.test_doubles

--- a/preview/touch/test/CMakeLists.txt
+++ b/preview/touch/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_executable(preview.touch.test)
 emil_build_for(preview.touch.test BOOL PREVIEW_BUILD_TESTS)
-add_test(NAME preview.touch.test COMMAND preview.touch.test)
+emil_add_test(preview.touch.test)
 
 target_link_libraries(preview.touch.test PUBLIC
     preview.interfaces.test_doubles

--- a/preview/views/test/CMakeLists.txt
+++ b/preview/views/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_executable(preview.views.test)
 emil_build_for(preview.views.test BOOL PREVIEW_BUILD_TESTS)
-add_test(NAME preview.views.test COMMAND preview.views.test)
+emil_add_test(preview.views.test)
 
 target_link_libraries(preview.views.test PUBLIC
     preview.interfaces.test_doubles


### PR DESCRIPTION
use emil_add_test instead of add_test so that the tests are not added to ctest when they are excluded from the build