### PR TITLE
ci: update moved release-please-action action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,7 +27,7 @@ jobs:
       #    app_id: ${{ secrets.FOREST_RELEASER_APP_ID }}
       #    app_base64_private_key: ${{ secrets.FOREST_RELEASER_APP_PRIVATE_KEY_BASE64 }}
       #    auth_type: installation
-      - uses: google-github-actions/release-please-action@a37ac6e4f6449ce8b3f7607e4d97d0146028dc0b # v4.1.0
+      - uses: googleapis/release-please-action@f3969c04a4ec81d7a9aa4010d84ae6a7602f86a7 # v4.1.1
         id: release
         with:
           command: manifest


### PR DESCRIPTION
google-github-actions/release-please-action is deprecated, please use googleapis/release-please-action instead.